### PR TITLE
fix(@ngaox/seo): use name for Twitter Card image alt

### DIFF
--- a/packages/seo/src/lib/seo.service.ts
+++ b/packages/seo/src/lib/seo.service.ts
@@ -102,7 +102,7 @@ export class SeoService {
       }
       if (image.alt) {
         this.generateTags([
-          { property: 'twitter:image:alt', content: image.alt },
+          { name: 'twitter:image:alt', content: image.alt },
           { property: 'og:image:alt', content: image.alt }
         ]);
       }


### PR DESCRIPTION
### Summary
Twitter Card's image alt `<meta>` is using `property` attribute instead of `name`. Rest of Twitter Card metas are using `name` as specified in specs.


### Details

### Checks
- [ ] Changes has been tested
- [x] I have mentioned all related issues
- [x] My PR follows the [Conventional Commits spec](https://www.conventionalcommits.org/)
- [x] I follow the project [Code of Conduct](https://github.com/rabraghib/.github/blob/main/CODE_OF_CONDUCT.md)
